### PR TITLE
no need to run curl as sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,28 +21,28 @@ Basic usage, force rebuild, switch branch are the preferred operations, as you'l
 ```
 sudo bash
 <password>
-sudo curl https://raw.githubusercontent.com/Jarli01/xenorchestra_updater/master/xo-update.sh | bash
+curl https://raw.githubusercontent.com/Jarli01/xenorchestra_updater/master/xo-update.sh | sudo bash
 ```
 
 ### Force rebuild
 ```
 sudo bash
 <password>
-sudo curl https://raw.githubusercontent.com/Jarli01/xenorchestra_updater/master/xo-update.sh | bash -s -- -f 
+curl https://raw.githubusercontent.com/Jarli01/xenorchestra_updater/master/xo-update.sh | sudo bash -s -- -f 
 ```
 
 ### Switch branch
 ```
 sudo bash
 <password>
-sudo curl https://raw.githubusercontent.com/Jarli01/xenorchestra_updater/master/xo-update.sh | bash -s -- -b next-release
+curl https://raw.githubusercontent.com/Jarli01/xenorchestra_updater/master/xo-update.sh | sudo bash -s -- -b next-release
 ```
 
 ### Update Node
 ```
 sudo bash
 <password>
-sudo curl https://raw.githubusercontent.com/Jarli01/xenorchestra_updater/master/xo-update.sh | bash -s -- -n stable
+curl https://raw.githubusercontent.com/Jarli01/xenorchestra_updater/master/xo-update.sh | sudo bash -s -- -n stable
 ```
 
 ### Installing Yarn


### PR DESCRIPTION
i'm mainly trying to improve the educational value for linux newbies.

after my minimal fix i still don't like the situation, mainly bec. i understand you're trying to cater to two groups of people:

1) some people will be able to drop the first sudo bash, bec. their sudo doesn't require a password
2) people that need to enter a password will need the first line, but they shouldn't need any sudo bash in the second line

the only real solution IMO is to never use sudo and tell the user: "please run this as root".
personally i didn't have sudo installed, that's why i noticed all these peculiarities.